### PR TITLE
Fixed syntax errors on some schemas.

### DIFF
--- a/generated/recruitment.raml.html
+++ b/generated/recruitment.raml.html
@@ -1001,10 +1001,9 @@
                 "id": {
                     "type": "integer"
                 }
-            }
-        },
-        "required": [ "id" ]
-        
+            },
+            "required": [ "id" ]
+        }
     },
     "type": "array",
     "items": { "$ref": "#/definitions/candidate" },
@@ -1604,7 +1603,7 @@
                     "type": "boolean"
                 }
             },
-            "required": "someMandatory",
+            "required": ["someMandatory"],
             "additionalProperties": false
         },
         "jobRule": {

--- a/schemas/candidateEditSpec.json
+++ b/schemas/candidateEditSpec.json
@@ -94,7 +94,7 @@
                     "type": "boolean"
                 }
             },
-            "required": "someMandatory",
+            "required": ["someMandatory"],
             "additionalProperties": false
         },
         "jobRule": {

--- a/schemas/candidates.json
+++ b/schemas/candidates.json
@@ -6,10 +6,9 @@
                 "id": {
                     "type": "integer"
                 }
-            }
-        },
-        "required": [ "id" ]
-        
+            },
+            "required": [ "id" ]
+        }
     },
     "type": "array",
     "items": { "$ref": "#/definitions/candidate" },


### PR DESCRIPTION
candidates.json has the required in the wrong scope.

candidateEditSpec.json had a required statement as a string, not an
array of strings.