### PR TITLE
Require unique category values

### DIFF
--- a/schemas/categoriesActual.json
+++ b/schemas/categoriesActual.json
@@ -9,6 +9,7 @@
                 },
                 "values": {
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "type": "integer"
                     }


### PR DESCRIPTION
This would allow code generation tools to generate this property as a set instead of a list.