### PR TITLE
Revert "remove assessment hub email capability"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ Change (non-breaking) - add daysToExpireIsFixed to assessmentType.json. Affects:
     GET /assessmentTypes
     GET /assessmentTypes/forApp
 
-Change (breaking) - remove appCommunicatesDirectlyToCandidate from assessmentType.json. Affects:
+Change (non-breaking) - deprecate appCommunicatesDirectlyToCandidate from assessmentType.json. Affects:
 	GET /assessmentTypes
 	GET /assessmentTypes/byID/{}
 

--- a/docs/schemas/assessmentType.json
+++ b/docs/schemas/assessmentType.json
@@ -40,6 +40,10 @@
     "userDescription": {
       "type": "string",
       "description": "A description, worded for the user, of the purpose of this assessment. Markdown format. e.g.: Video interview captures a short video from the candidate."
+    },
+    "appCommunicatesDirectlyToCandidate": {
+      "type": "boolean",
+      "description": "Deprecated - all apps should communicate directly to candidates"
     }
   },
   "type": "object",
@@ -74,6 +78,9 @@
     "userDescription": {
       "$ref": "#/definitions/userDescription"
     },
+    "appCommunicatesDirectlyToCandidate": {
+      "$ref": "#/definitions/appCommunicatesDirectlyToCandidate"
+    },
     "image": {
       "$ref": "assessmentRead.json#/definitions/imageUrl"
     }
@@ -85,6 +92,7 @@
     "isPassFail",
     "canReuse",
     "userDescription",
+    "appCommunicatesDirectlyToCandidate",
     "image"
   ]
 }


### PR DESCRIPTION
 - this functionality has been deprecated and will be removed in a future version