### PR TITLE
Remove unnecessary attribute since it's confusing

### DIFF
--- a/docs/schemas/itemRead.json
+++ b/docs/schemas/itemRead.json
@@ -42,10 +42,6 @@
         "callback": {
           "$ref": "itemMeta.json#/definitions/callback"
         },
-        "id": {
-          "type": "integer",
-          "description": "a unique id for picklist choice"
-        },
         "name": {
           "$ref": "#/definitions/name"
         },

--- a/docs/schemas/itemWrite.json
+++ b/docs/schemas/itemWrite.json
@@ -118,10 +118,6 @@
         "callback": {
           "$ref": "itemMeta.json#/definitions/callback"
         },
-        "id": {
-          "type": "integer",
-          "description": "a unique id for picklist choice"
-        },
         "name": {
           "$ref": "itemRead.json#/definitions/name"
         },


### PR DESCRIPTION
The "id" attribute I removed should be only in pickChoice rather than pickListItem since pickListItem doesn't need id.